### PR TITLE
Fixes #4439

### DIFF
--- a/templates/repo/commits_table.tmpl
+++ b/templates/repo/commits_table.tmpl
@@ -40,14 +40,14 @@
 							{{end}}
 						</td>
 
-						<td class="message collapsing has-emoji">
+						<td class="message collapsing">
 							{{/* Username or Reponame doesn't present we assume the source repository no longer exists */}}
 							{{if not (and $.Username $.Reponame)}}
 								<span class="ui sha label">{{ShortSHA1 .ID.String}}</span>
 							{{else}}
 								<a rel="nofollow" class="ui sha label" href="{{AppSubURL}}/{{$.Username}}/{{$.Reponame}}/commit/{{.ID}}">{{ShortSHA1 .ID.String}}</a>
 							{{end}}
-							<span {{if gt .ParentCount 1}}class="grey text"{{end}}>{{RenderCommitMessage false .Summary $.RepoLink $.Repository.ComposeMetas}}</span>
+							<span class="{{if gt .ParentCount 1}}grey text {{end}} has-emoji">{{RenderCommitMessage false .Summary $.RepoLink $.Repository.ComposeMetas}}</span>
 						</td>
 						<td class="grey text right aligned">{{TimeSince .Author.When $.Lang}}</td>
 					</tr>


### PR DESCRIPTION
This is a basic pull request to fix #4439; the `has-emoji` class seems to need to be on the html element that contains the emoji. In this case the html element that has the emoji is a child of the element with the `has-emoji` class, it was being ignored.

What I have done here is move the `has-emoji` class from the parent `<tr>`, attaching it to the child `<span>` element that contains the commit message with the potential of having emoji.

Before:
![image](https://cloud.githubusercontent.com/assets/464699/25223534/88e2244a-25b3-11e7-986b-0e0a7b67d8dd.png)

After:
![image](https://cloud.githubusercontent.com/assets/464699/25223456/56560f1e-25b3-11e7-9279-be8d1df1cc64.png)
